### PR TITLE
lowercase license and readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ project-root/
 |_ test/
 |_ node_modules/
 |_ package.json
-|_ README.md
+|_ readme.md
 |_ .gitignore
 |_ ..
 ```
@@ -46,8 +46,8 @@ project-root/
 |_ node_modules/
 |_ index.js
 |_ package.json
-|_ README.md
-|_ LICENSE.md
+|_ readme.md
+|_ license.md
 |_ .gitignore
 |_ ..
 ```


### PR DESCRIPTION
on case sensitive file systems the all caps license and readme is a bit of a pain, what do people think of using lowercase ones as the standard?
