### PR TITLE
Expand list of eslint rules

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -1,21 +1,54 @@
 {
+  "globals": {
+    "google": false,
+    "cartodb": false
+  },
   "env": {
     "node": true,
-    "browser": true,
     "es6": true
   },
-  "ecmaFeatures": {
-    "modules": true
+  "parser": "babel-eslint",
+  "parserOptions": {
+    "ecmaVersion": 6,
+    "sourceType": "module",
+    "ecmaFeatures": {
+      "jsx": true
+    }
   },
   "rules": {
-   "indent": [2, 2],
-   "brace-style": [2, "1tbs"],
-   "quotes": [2, "single"],
-   "no-console": 1,
-   "no-use-before-define": [2, "nofunc"],
-   "no-underscore-dangle": 0,
-   "no-constant-condition": 0,
-   "space-before-function-paren": [2, {"anonymous": "always", "named": "never"}],
-   "func-style": [2, "declaration"]
+    "array-bracket-spacing": [2, "never"],
+    "block-spacing": [2, "always"],
+    "brace-style": [2, "1tbs"],
+    "complexity": [1, 10],
+    "comma-spacing": [2, { "after": true }],
+    "comma-style": [2, "last"],
+    "consistent-this": [2, "self"],
+    "indent": [2, 2, { "SwitchCase": 1 }],
+    "key-spacing": [2, { "beforeColon": false, "afterColon": true, "mode": "minimum" }],
+    "keyword-spacing": [2, { "before": true, "after": true }],
+    "max-statements-per-line": [2, { "max": 1 }],
+    "new-parens": 2,
+    "no-array-constructor": 2,
+    "no-console": 1,
+    "no-constant-condition": 0,
+    "no-extra-parens": 0,
+    "no-irregular-whitespace": 2,
+    "no-lonely-if": 2,
+    "no-mixed-spaces-and-tabs": 2,
+    "no-negated-condition": 2,
+    "no-nested-ternary": 2,
+    "no-spaced-func": 2,
+    "no-trailing-spaces": 2,
+    "no-underscore-dangle": 0,
+    "no-use-before-define": [2, "nofunc"],
+    "no-whitespace-before-property": 2,
+    "object-curly-spacing": [2, "always"],
+    "quotes": [2, "single"],
+    "semi": [2, "always"],
+    "semi-spacing": 2,
+    "space-before-blocks": [2, "always"],
+    "space-in-parens": [2, "never"],
+    "spaced-comment": [2, "always"]
   }
 }
+


### PR DESCRIPTION
I just added this expanded list of rules on a couple of non-trivial projects, and I've found it makes the already predominant style in those code bases more explicit, and catches inconsistencies in spacing well.

Also, eslint has a `--fix` flag which auto corrects nearly all of these issues. It's really nice to try it and then review the commit diff to see what changed.

Thoughts on these?
